### PR TITLE
Don't use padding and min size as the floor for a node's calculated flex basis

### DIFF
--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -99,10 +99,8 @@ static void computeFlexBasisForChild(
         (child->getConfig()->isExperimentalFeatureEnabled(
              ExperimentalFeature::WebFlexBasis) &&
          child->getLayout().computedFlexBasisGeneration != generationCount)) {
-      const FloatOptional paddingAndBorder = FloatOptional(
-          paddingAndBorderForAxis(child, mainAxis, direction, ownerWidth));
       child->setLayoutComputedFlexBasis(
-          yoga::maxOrDefined(resolvedFlexBasis, paddingAndBorder));
+          yoga::maxOrDefined(resolvedFlexBasis, FloatOptional(0)));
     }
   } else if (isMainAxisRow && isRowStyleDimDefined) {
     // The width is definite, so use that as the flex basis.
@@ -255,7 +253,7 @@ static void computeFlexBasisForChild(
 
     child->setLayoutComputedFlexBasis(FloatOptional(yoga::maxOrDefined(
         child->getLayout().measuredDimension(dimension(mainAxis)),
-        paddingAndBorderForAxis(child, mainAxis, direction, ownerWidth))));
+        0.0f)));
   }
   child->setLayoutComputedFlexBasisGeneration(generationCount);
 }
@@ -629,7 +627,6 @@ static float distributeFreeSpaceSecondPass(
     LayoutData& layoutMarkerData,
     const uint32_t depth,
     const uint32_t generationCount) {
-  float childFlexBasis = 0;
   float flexShrinkScaledFactor = 0;
   float flexGrowFactor = 0;
   float deltaFreeSpace = 0;
@@ -637,14 +634,9 @@ static float distributeFreeSpaceSecondPass(
   const bool isNodeFlexWrap = node->style().flexWrap() != Wrap::NoWrap;
 
   for (auto currentLineChild : flexLine.itemsInFlow) {
-    childFlexBasis = boundAxisWithinMinAndMax(
-                         currentLineChild,
-                         direction,
-                         mainAxis,
-                         currentLineChild->getLayout().computedFlexBasis,
-                         mainAxisOwnerSize,
-                         ownerWidth)
-                         .unwrap();
+    // Use the child's raw flex basis as our starting point. Min/max clamping
+    // happens later with calls to boundAxis.
+    const float childFlexBasis = currentLineChild->getLayout().computedFlexBasis.unwrap();
     float updatedMainSize = childFlexBasis;
 
     if (yoga::isDefined(flexLine.layout.remainingFreeSpace) &&
@@ -825,14 +817,9 @@ static void distributeFreeSpaceFirstPass(
   float deltaFreeSpace = 0;
 
   for (auto currentLineChild : flexLine.itemsInFlow) {
-    float childFlexBasis = boundAxisWithinMinAndMax(
-                               currentLineChild,
-                               direction,
-                               mainAxis,
-                               currentLineChild->getLayout().computedFlexBasis,
-                               mainAxisOwnerSize,
-                               ownerWidth)
-                               .unwrap();
+    // Use the child's raw flex basis as our starting point. Min/max clamping
+    // happens later with calls to boundAxis.
+    const float childFlexBasis = currentLineChild->getLayout().computedFlexBasis.unwrap();
 
     if (flexLine.layout.remainingFreeSpace < 0) {
       flexShrinkScaledFactor =

--- a/yoga/algorithm/FlexLine.cpp
+++ b/yoga/algorithm/FlexLine.cpp
@@ -86,7 +86,20 @@ FlexLine calculateFlexLine(
 
     sizeConsumedIncludingMinConstraint += flexBasisWithMinAndMaxConstraints +
         childMarginMainAxis + childLeadingGapMainAxis;
-    sizeConsumed += flexBasisWithMinAndMaxConstraints + childMarginMainAxis +
+    // If the node is flexible then use the child's 'raw' computed flex basis
+    // so filling nodes with the same flex basis consume the same size. Any
+    // min/max constraints are applied later during actual distribution of the
+    // available space. We clamp the computed flex basis to the node's max just
+    // in case it's been set larger.
+    //
+    // Non-flexible items use their fixed size as their flex basis (see
+    // computeFlexBasisForChild) so we use the clamped value here since that's
+    // exactly how much space they will consume.
+    const float flexBasisForDistribution =
+      child->isNodeFlexible()
+          ? yoga::minOrDefined(child->getLayout().computedFlexBasis.unwrap(), flexBasisWithMinAndMaxConstraints)
+          : flexBasisWithMinAndMaxConstraints;
+    sizeConsumed += flexBasisForDistribution + childMarginMainAxis +
         childLeadingGapMainAxis;
 
     if (child->isNodeFlexible()) {


### PR DESCRIPTION
This isn't how CSS works, and it's not how we want our "fill" behaviour to work either. Yoga seems to use a node's calculated basis as a stand-in for its size along the main axis. This in turn means that for a fill node it would effectively fill starting from its flex basis (which may be its min size, or padding). (The reality here is a bit more complicated as the flex basis would also be used to calculate how much space is consumed on a line, and therefore what is left to be divided up among filling child nodes.)

Instead we no longer include padding when determining a flexible node's calculated flex basis, and we no longer use a node's min size as the floor for its calculated flex basis (this seemed to only happen when calculating the space consumed on a line).

Padding (and borders) are still accounted for when setting the calculated flex basis for a _fixed-size_ node (since that value should be the node's total effective size which includes padding).

I took a good look at the code surrounding these changes, and the different call sites, and from what I understand it seems safe to me. And after some back and forth with the robot it says it's safe, too (FWIW).